### PR TITLE
[Bug] Sort indices before pull cols

### DIFF
--- a/spark-on-angel/mllib/src/main/scala/com/tencent/angel/spark/ml/util/ModelLoader.scala
+++ b/spark-on-angel/mllib/src/main/scala/com/tencent/angel/spark/ml/util/ModelLoader.scala
@@ -18,6 +18,8 @@ import com.tencent.angel.ml.psf.columns._
 import com.tencent.angel.ps.server.data.request.UpdateOp
 import com.tencent.angel.psagent.PSAgentContext
 
+import scala.util.Sorting
+
 object ModelLoader {
 
   def load(path: String,
@@ -184,7 +186,9 @@ object ModelLoader {
 
       // update embedding
       val rows = (0 until numFactors).toArray
-      val updateIndices = VFactory.denseIntVector(embeddingIndices.toIntArray())
+      val updateIndicesValues = embeddingIndices.toIntArray()
+      Sorting.quickSort(updateIndicesValues)
+      val updateIndices = VFactory.denseIntVector(updateIndicesValues)
       val param = new UpdateColsParam(embeddingId, rows, updateIndices, update, UpdateOp.REPLACE)
       val func  = new UpdateColsFunc(param)
       PSAgentContext.get().getUserRequestAdapter.update(func).get()


### PR DESCRIPTION
Sorting get Indices before calling the GetColumnFunc.
When calling this function, we must make sure that the indices are sorted.