### PR TITLE
fix buildHistogram index

### DIFF
--- a/angel-ps/mllib/src/main/scala/com/tencent/angel/ml/GBDT/algo/RegTree/GradHistHelper.java
+++ b/angel-ps/mllib/src/main/scala/com/tencent/angel/ml/GBDT/algo/RegTree/GradHistHelper.java
@@ -91,7 +91,7 @@ public class GradHistHelper {
         }
         // 3.4.3. find the position of feature value in a histogram
         // the search area in the sketch is [fid * #splitNum, (fid+1) * #splitNum - 1]
-        int start = fPos * splitNum;
+        int start = fid * splitNum;
         int end;  // inclusive
         if (this.controller.cateFeatNum.containsKey(fid)) {
           end = start + this.controller.cateFeatNum.get(fid) - 1;


### PR DESCRIPTION
The `sketches` contains all features, so the `start` and `end` point should use original feature indices, rather than sampled ones

@paynie plz review