### PR TITLE
estimate memory usage for gradient and prediction on executor

### DIFF
--- a/spark-on-angel/mllib/src/main/scala/com/tencent/angel/spark/ml/tree/gbdt/metadata/InstanceInfo.scala
+++ b/spark-on-angel/mllib/src/main/scala/com/tencent/angel/spark/ml/tree/gbdt/metadata/InstanceInfo.scala
@@ -35,6 +35,8 @@ object InstanceInfo {
     // 2 class: preds of each instance
     // multi-class one-tree: probs_ins_1, probs_ins_2, ...
     // multi-class multi-tree: probs_ins_1, probs_ins_2, ...
+    val totalSize = predSize / math.pow(10, 9) + 2 * numData / math.pow(10, 9) + 2 * gradSize / math.pow(10, 9)
+    println(s"InstanceInfo costs about ${4 * totalSize} GB memory")
     val predictions = new Array[Float](predSize)
     val weights = Array.fill[Float](numData)(1.0f)
     val gradients = new Array[Double](gradSize)

--- a/spark-on-angel/mllib/src/main/scala/com/tencent/angel/spark/ml/tree/gbdt/trainer/GBDTTrainer.scala
+++ b/spark-on-angel/mllib/src/main/scala/com/tencent/angel/spark/ml/tree/gbdt/trainer/GBDTTrainer.scala
@@ -237,7 +237,7 @@ class GBDTTrainer(param: GBDTParam) extends Serializable {
       .mapPartitions(iterator => Iterator(Dataset[Int, Float](iterator.toSeq)))
       .persist()
     val numTrain = trainDP.map(_.size).collect().sum
-    println(s"Load data cost ${System.currentTimeMillis() - loadStart} ms")
+    println(s"Load data cost ${System.currentTimeMillis() - loadStart} ms, number of instances: $numTrain")
 
     // 2. collect labels, ensure 0-based indexed and broadcast
     val labelStart = System.currentTimeMillis()


### PR DESCRIPTION
#744 
Feature-parallel GBDT needs extra memory to store gradients and predictions.
To help the user know the memory assumption, we estimate this storage cost.