### PR TITLE
Basic Structure of recording derivation information of cross-features

### DIFF
--- a/spark-on-angel/automl/src/main/scala/com/tencent/angel/spark/automl/feature/PipelineDriver.scala
+++ b/spark-on-angel/automl/src/main/scala/com/tencent/angel/spark/automl/feature/PipelineDriver.scala
@@ -38,7 +38,7 @@ object PipelineDriver {
 
     pipelineWrapper.setStages(stages)
 
-    val model: PipelineModel = pipelineWrapper.fit(inputDF)
+    val model: PipelineModelWrapper = pipelineWrapper.fit(inputDF)
 
     val outDF = model.transform(inputDF)
 

--- a/spark-on-angel/automl/src/main/scala/com/tencent/angel/spark/automl/feature/PipelineWrapper.scala
+++ b/spark-on-angel/automl/src/main/scala/com/tencent/angel/spark/automl/feature/PipelineWrapper.scala
@@ -1,18 +1,61 @@
+/*
+ * Tencent is pleased to support the open source community by making Angel available.
+ *
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+
 package com.tencent.angel.spark.automl.feature
 
 import org.apache.spark.ml.{Pipeline, PipelineModel, PipelineStage}
-import org.apache.spark.sql.Dataset
+import org.apache.spark.sql.{DataFrame, Dataset}
 
 class PipelineWrapper() {
 
   var pipeline = new Pipeline()
 
+  var transformers: Array[TransformerWrapper] = Array()
+
+  def setTransformers(value: Array[TransformerWrapper]): this.type = {
+    transformers = value
+    setStages(PipelineBuilder.build(transformers))
+    this
+  }
+
   def setStages(value: Array[_ <: PipelineStage]): Unit = {
     pipeline = pipeline.setStages(value)
   }
 
-  def fit(dataset: Dataset[_]): PipelineModel = {
-    pipeline.fit(dataset)
+  def fit(dataset: Dataset[_]): PipelineModelWrapper = {
+    new PipelineModelWrapper(pipeline.fit(dataset), transformers)
   }
 
+}
+
+class PipelineModelWrapper(val model: PipelineModel,
+                           val transformers: Array[TransformerWrapper]) {
+
+  def transform(dataset: Dataset[_]): DataFrame = {
+    var df = model.transform(dataset)
+    if (transformers.length >= 2) {
+      (0 until transformers.length - 1).foreach{ i =>
+        val outCols = transformers(i).getOutputCols
+        for (col <- outCols) {
+          df = df.drop(col)
+        }
+      }
+    }
+    df
+  }
 }

--- a/spark-on-angel/automl/src/main/scala/org/apache/spark/ml/feature/operator/MetadataTransformUtils.scala
+++ b/spark-on-angel/automl/src/main/scala/org/apache/spark/ml/feature/operator/MetadataTransformUtils.scala
@@ -1,0 +1,113 @@
+/*
+ * Tencent is pleased to support the open source community by making Angel available.
+ *
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.spark.ml.feature.operator
+
+import org.apache.spark.sql.types.{MetadataBuilder, StructField}
+import org.apache.spark.sql.{DataFrame, Dataset}
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * The factory to record the generation information for each feature in the pipeline
+  */
+object MetadataTransformUtils {
+
+  final val DERIVATION: String = "derivation"
+
+  /**
+    * Check and initialization.
+    * @param numFeatures: the number of features
+    * @return
+    */
+  private def createDerivation(numFeatures: Int): Array[String] = {
+    val arrayBuffer = ArrayBuffer[String]()
+    (0 until numFeatures).foreach{ i =>
+      arrayBuffer.append("f_" + i.toString)
+    }
+    arrayBuffer.toArray
+  }
+
+  /**
+    *
+    * @param feature1
+    * @param feature2
+    * @return Array[String]
+    */
+  private def cartesianWithArray(feature1: Array[String], feature2: Array[String]): Array[String] = {
+    val res = ArrayBuffer[String]()
+    feature1.foreach{ f1 =>
+      feature2.foreach{ f2 =>
+        res.append("(" + f1 + " x " + f2 + ")")
+      }
+    }
+    res.toArray
+  }
+
+  /**
+    *
+    * @param field
+    * @param filterIndices
+    * @param numFeatures
+    * @return
+    */
+  def featureSelectionTransform(field: StructField, // Metadata is private[types]
+                                filterIndices: Array[Int],
+                                numFeatures: Int): MetadataBuilder = {
+    val metadata = field.metadata
+
+    var derivation = Array[String]()
+    if (metadata.contains(DERIVATION)) {
+      derivation = filterIndices map metadata.getStringArray(DERIVATION)
+    } else {
+      derivation = createDerivation(numFeatures)
+    }
+
+    new MetadataBuilder().withMetadata(metadata).putStringArray(DERIVATION, derivation)
+  }
+
+  /**
+    *
+    * @param fields: The Array[StructField]
+    * @param numFeatures number of features
+    * @return
+    */
+  def vectorCartesianTransform(fields: Array[StructField], numFeatures: Int): MetadataBuilder = {
+    if (fields.length < 2) {
+      throw new IllegalArgumentException("the number of cols in the input DataFrame should be no less than 2")
+    }
+
+    var res = Array[String]()
+    if (fields.head.metadata.contains(DERIVATION)) {
+      res = fields.head.metadata.getStringArray(DERIVATION)
+    } else {
+      res = createDerivation(numFeatures)
+    }
+
+    for (i <- 1 until fields.length) {
+      if (fields(i).metadata.contains(DERIVATION)) {
+        res = cartesianWithArray(res, fields(i).metadata.getStringArray(DERIVATION))
+      } else {
+        res = cartesianWithArray(res, createDerivation(numFeatures))
+      }
+    }
+
+    val metadata = fields.last.metadata
+    new MetadataBuilder().withMetadata(metadata).putStringArray(DERIVATION, res)
+  }
+
+}

--- a/spark-on-angel/automl/src/main/scala/org/apache/spark/ml/feature/operator/RandomForestSelector.scala
+++ b/spark-on-angel/automl/src/main/scala/org/apache/spark/ml/feature/operator/RandomForestSelector.scala
@@ -31,7 +31,7 @@ import org.apache.spark.mllib.linalg.{Vector => OldVector, Vectors => OldVectors
 import org.apache.spark.mllib.stat.{MultivariateStatisticalSummary, Statistics}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.functions.{col, udf}
-import org.apache.spark.sql.types.{StructField, StructType}
+import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 
 /**
@@ -217,7 +217,12 @@ class RandomForestSelectorModel(override val uid: String,
             + vector.getClass.getSimpleName + " is given.")
       }
     }
-    dataset.withColumn($(outputCol), select(col($(featuresCol))))
+
+    dataset.withColumn(
+      $(outputCol),
+      select(col($(featuresCol))),
+      MetadataTransformUtils.featureSelectionTransform(
+        dataset.select(${featuresCol}).schema.fields.last, filterIndices, selectedFeatures.length).build())
   }
 
   override def copy(extra: ParamMap): RandomForestSelectorModel = {

--- a/spark-on-angel/automl/src/main/scala/org/apache/spark/ml/feature/operator/VectorCartesian.scala
+++ b/spark-on-angel/automl/src/main/scala/org/apache/spark/ml/feature/operator/VectorCartesian.scala
@@ -89,9 +89,16 @@ class VectorCartesian (override val uid: String) extends Transformer
 
     val featureCols = inputFeatures.map { f => dataset(f.name) }
 
-    dataset.select(
-      col("*"),
-      interactFunc(struct(featureCols: _*)).as($(outputCol), featureAttrs.toMetadata()))
+    val fields: Array[StructField] = $(inputCols).map(inputCol => dataset.select(inputCol).schema.fields.last)
+//    dataset.select(
+//      col("*"),
+//      interactFunc(struct(featureCols: _*)).as($(outputCol), featureAttrs.toMetadata()))
+
+    dataset.select(col("*"),
+      interactFunc(struct(featureCols: _*)).as(
+        $(outputCol),
+        MetadataTransformUtils.vectorCartesianTransform(fields, vectorDims(0)).build()))
+
   }
 
   private def getVectorDimension(dataset: Dataset[_], cols: Array[String]): Array[Int] = {

--- a/spark-on-angel/automl/src/test/scala/com/tencent/angel/spark/automl/FeatureSelectorTest.scala
+++ b/spark-on-angel/automl/src/test/scala/com/tencent/angel/spark/automl/FeatureSelectorTest.scala
@@ -81,6 +81,8 @@ class FeatureSelectorTest {
     val selectedTrainDF = selectorModel.transform(trainDF)
     val selectedTestDF = selectorModel.transform(testDF)
 
+    selectedTestDF.select("selectedFeatures").schema.fields.foreach(f => println(f.metadata.toString()))
+
     val selectedLR = new LogisticRegression()
       .setMaxIter(20)
       .setFeaturesCol("selectedFeatures")

--- a/spark-on-angel/automl/src/test/scala/com/tencent/angel/spark/automl/MetadataTest.scala
+++ b/spark-on-angel/automl/src/test/scala/com/tencent/angel/spark/automl/MetadataTest.scala
@@ -1,0 +1,93 @@
+/*
+ * Tencent is pleased to support the open source community by making Angel available.
+ *
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.tencent.angel.spark.automl
+
+import org.apache.spark.ml.Pipeline
+import org.apache.spark.ml.feature.VectorAssembler
+import org.apache.spark.ml.feature.operator.{MetadataTransformUtils, VectorCartesian}
+import org.apache.spark.sql.SparkSession
+import org.junit.Test
+
+class MetadataTest {
+
+  val spark = SparkSession.builder().master("local").getOrCreate()
+
+  @Test
+  def testVectorCartesian(): Unit = {
+    val data = spark.read.format("libsvm")
+      .option("numFeatures", "123")
+      .load("../../data/a9a/a9a_123d_train_trans.libsvm")
+      .persist()
+
+    val cartesian = new VectorCartesian()
+      .setInputCols(Array("features", "features"))
+      .setOutputCol("cartesian_features")
+
+    val assembler = new VectorAssembler()
+      .setInputCols(Array("features", "cartesian_features"))
+      .setOutputCol("assemble_features")
+
+    val pipeline = new Pipeline()
+      .setStages(Array(cartesian, assembler))
+
+    val featureModel = pipeline.fit(data)
+    val crossDF = featureModel.transform(data)
+
+    crossDF.schema.fields.foreach{ field =>
+      println("name: " + field.name)
+      println("metadata: " + field.metadata.toString())
+    }
+
+    spark.close()
+
+  }
+
+  @Test
+  def testThreeOrderCartesian(): Unit = {
+    val data = spark.read.format("libsvm")
+      .option("numFeatures", 8)
+      .load("../../data/abalone/abalone_8d_train.libsvm")
+      .persist()
+
+    val cartesian = new VectorCartesian()
+      .setInputCols(Array("features", "features"))
+      .setOutputCol("f_f")
+
+    val cartesian2 = new VectorCartesian()
+      .setInputCols(Array("features", "f_f"))
+      .setOutputCol("f_f_f")
+
+    val pipeline = new Pipeline()
+      .setStages(Array(cartesian, cartesian2))
+
+    val crossDF = pipeline.fit(data).transform(data).persist()
+
+    // first cartesian, the number of dimensions is 64
+    println(crossDF.select("f_f").schema.fields.last.metadata.getStringArray(MetadataTransformUtils.DERIVATION).length)
+    // second cartesian, the number of dimensions is 512
+    println(crossDF.select("f_f_f").schema.fields.last.metadata.getStringArray(MetadataTransformUtils.DERIVATION).length)
+
+
+    crossDF.select("f_f").schema.fields.last.metadata.getStringArray(MetadataTransformUtils.DERIVATION).foreach(str => println(str + ", "))
+    println()
+    crossDF.select("f_f_f").schema.fields.last.metadata.getStringArray(MetadataTransformUtils.DERIVATION).foreach(str => println(str + ", "))
+
+    spark.close()
+  }
+
+}


### PR DESCRIPTION
1. Modify the PipelineWrapper, when the fit process is finished, the intermediate dataframes are dropped. 
2 Complete the basic structure of recording the derivation information of cross-features. Modify the `transform` method in `RandomForestSelector` and `VectorCartesian` class.