### PR TITLE
Fix bug: invalid input file name for local/word2vecExample

### DIFF
--- a/spark-on-angel/examples/src/main/scala/com/tencent/angel/spark/examples/local/Word2vecExample.scala
+++ b/spark-on-angel/examples/src/main/scala/com/tencent/angel/spark/examples/local/Word2vecExample.scala
@@ -44,12 +44,12 @@ object Word2vecExample {
     sc.setLogLevel("ERROR")
     PSContext.getOrCreate(sc)
 
-    val input = "data/text8/text8.split.remapping"
+    val input = "data/text8/text8.split.head"
 
     val data = sc.textFile(input)
     data.cache()
 
-    val (corpus) = Features.corpusStringToIntWithoutRemapping(sc.textFile(input))
+    val (corpus, _) = Features.corpusStringToInt(sc.textFile(input))
     val docs = corpus.repartition(1)
 
     docs.cache()

--- a/spark-on-angel/examples/src/main/scala/com/tencent/angel/spark/examples/local/Word2vecWorkerExample.scala
+++ b/spark-on-angel/examples/src/main/scala/com/tencent/angel/spark/examples/local/Word2vecWorkerExample.scala
@@ -26,13 +26,13 @@ object Word2vecWorkerExample {
     sc.setLogLevel("ERROR")
     PSContext.getOrCreate(sc)
 
-    val input = "data/text8/text8.split.remapping"
+    val input = "data/text8/text8.split.head"
     val output = "model/"
 
     val data = sc.textFile(input)
     data.cache()
 
-    val (corpus) = Features.corpusStringToIntWithoutRemapping(sc.textFile(input))
+    val (corpus, _) = Features.corpusStringToInt(sc.textFile(input))
     val docs = corpus.repartition(1)
 
     docs.cache()


### PR DESCRIPTION
The input file name of local/word2vecExample and local/word2vecExampleWorker is invalid. 
To solve this, we change it from "data/text8/text8.split.remapping" to "data/text8/text8.split.head"