### PR TITLE
#947 fclayerParams.split("|")  字符串基于基于特殊字符 | 需添加 转义符号,变更为fclayerParams.spl…

### DIFF
--- a/angel-ps/mllib/src/main/scala/com/tencent/angel/ml/classification/DeepFM.scala
+++ b/angel-ps/mllib/src/main/scala/com/tencent/angel/ml/classification/DeepFM.scala
@@ -47,7 +47,7 @@ class DeepFM(conf: SharedConf, _ctx: TaskContext = null) extends AngelModel(conf
     // outputDim:transFunc:optimizer
     var fcLayer: Layer = innerSumCross
     val fclayerParams = conf.get(MLCoreConf.ML_FCLAYER_PARAMS, MLCoreConf.DEFAULT_ML_FCLAYER_PARAMS)
-    fclayerParams.split("|").zipWithIndex.foreach{ case (params: String, idx: Int) =>
+    fclayerParams.split("\\|").zipWithIndex.foreach{ case (params: String, idx: Int) =>
       val name = s"fclayer_$idx"
       params.split(":") match {
         case Array(outputDim: String, transFunc: String, optimizer: String) =>


### PR DESCRIPTION
运行命令:
${ANGEL_HOME}/bin/angel-submit
-Dml.epoch.num=20
-Dangel.app.submit.class=com.tencent.angel.ml.core.graphsubmit.GraphRunner
-Dml.model.class.name=com.tencent.angel.ml.classification.DeepFM
-Dml.feature.index.range=$featureNum
-Dml.model.size=$featureNum
-Dml.data.validate.ratio=0.1
-Dml.data.type=libsvm
-Dml.learn.rate=0.1
-Dml.learn.decay=0.5
-Dml.reg.l2=0.03
-Daction.type=train
-Dml.sparseinputlayer.optimizer=ftrl
-Dangel.train.data.path=$input_path
-Dangel.save.model.path=$output_path
-Dangel.workergroup.number=20
-Dangel.worker.memory.mb=20000
-Dangel.worker.task.number=1
-Dangel.ps.number=20
-Dangel.ps.memory.mb=10000
-Dangel.task.data.storage.level=memory
-Dangel.job.name=angel_l1
-Dqueue=dev

deep 深度学习网络 在通过一下命令构建的时候会出现,buildNetwork 失败,通过排查为 DeepFM 的官方实现, 出现了参数解析的 bug,  通过修改解析表达式可以修复该问题 **fclayerParams.split("|")**  ;另外默认网络参数配置依赖
   <groupId>com.tencent.angel</groupId>
    <artifactId>angel-mlcore</artifactId>
    <version>0.1.1</version>

com.tencent.angel.mlcore.conf.MLCoreConf 当中的 全连接配置 多配置了一个: 需修正如下
val DEFAULT_ML_FCLAYER_PARAMS = "100:relu:momentum|100:relu:momentum|1:identity:momentum"
,否则还是不可以正常运行, 另外一个工程angel-mlcore 独立项目,稍后会单独提issure 

