### PR TITLE
#947 官方实现的 deepFM 无法正常运行,网络构建解析配置参数出现问题

### DIFF
--- a/angel-ps/mllib/src/main/scala/com/tencent/angel/ml/classification/DeepFM.scala
+++ b/angel-ps/mllib/src/main/scala/com/tencent/angel/ml/classification/DeepFM.scala
@@ -47,7 +47,7 @@ class DeepFM(conf: SharedConf, _ctx: TaskContext = null) extends AngelModel(conf
     // outputDim:transFunc:optimizer
     var fcLayer: Layer = innerSumCross
     val fclayerParams = conf.get(MLCoreConf.ML_FCLAYER_PARAMS, MLCoreConf.DEFAULT_ML_FCLAYER_PARAMS)
-    fclayerParams.split("|").zipWithIndex.foreach{ case (params: String, idx: Int) =>
+    fclayerParams.split("\\|").zipWithIndex.foreach{ case (params: String, idx: Int) =>
       val name = s"fclayer_$idx"
       params.split(":") match {
         case Array(outputDim: String, transFunc: String, optimizer: String) =>


### PR DESCRIPTION
`fclayerParams.split("|")`  字符串基于基于特殊字符 | 需添加 转义符号,变更为 `fclayerParams.split("\\|");` 否则参数解析错误,另外DeepFM 的正常运行还依赖
https://github.com/Angel-ML/mlcore/blob/master/src/main/scala/com/tencent/angel/mlcore/conf/MLCoreConf.scala

178    val DEFAULT_ML_FCLAYER_PARAMS = "100:relu:momentum|100::relu:momentum|1:identity:momentum"

目前这个默认配置是错误的多一个冒号,  应修改为  val DEFAULT_ML_FCLAYER_PARAMS = "100:relu:momentum|100:relu:momentum|1:identity:momentum"

mlcore 项目已提交合并请求,修复这些问题