### PR TITLE
Some column names in the environment page are spelled incorrectly

### DIFF
--- a/angel-ps/core/src/main/java/com/tencent/angel/webapp/page/EnvironmentBlock.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/webapp/page/EnvironmentBlock.java
@@ -55,8 +55,8 @@ public class EnvironmentBlock extends HtmlBlock {
     String OsNmae = System.getProperty("os.name");
     String JavaVersion = System.getProperty("java.version");
     run_info_table.tr().th(_TH, "NAME").th(_TH, "VALUE")._();
-    run_info_table.tr().td("UsrHome").td(UsrHome)._().tr().td("UsrDir").td(UsrDir)._().tr()
-      .td("UsrName").td(UsrName)._().tr().td("JavaHome").td(JavaHome)._().tr().td("OsNmae")
+    run_info_table.tr().td("UserHome").td(UsrHome)._().tr().td("UserDir").td(UsrDir)._().tr()
+      .td("UserName").td(UsrName)._().tr().td("JavaHome").td(JavaHome)._().tr().td("OsName")
       .td(OsNmae)._().tr().td("JavaVersion").td(JavaVersion)._();
     run_info_table._();
     html.h1("    ");


### PR DESCRIPTION
Some column names in the environment page of ps server are spelled incorrectly.

url:http://host/proxy/application_id/angel/angel/EnvironmentPage

UsrHome -> UserHome
UsrDir -> UserDir
UsrName -> UserName
OsName -> OsName

