### PR TITLE
Redact sentive properties in  Angel's environment page simlar to spark

### DIFF
--- a/angel-ps/core/src/main/java/com/tencent/angel/conf/AngelConf.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/conf/AngelConf.java
@@ -876,6 +876,15 @@ public class AngelConf extends Configuration {
    * Ps JVM parameters.
    */
   public static final String ANGEL_PS_JAVA_OPTS = ANGEL_PS_PREFIX + "java.opts";
+  
+  
+  /**
+   * Regex to decide which spark/hadoop configuration and environment variables contain sensitive information.
+   * When this regex matches a property key or value,the value is redacted from the Ps UI.
+   */
+  public static final String ANGEL_REDACTION_REGEX = "spark.redaction.regex";
+  public static final String DEFAULT_ANGEL_REDACTION_REGEX = "(?i)secret|password|token";
+  
 
   /**
    * Ps main class.

--- a/angel-ps/core/src/main/java/com/tencent/angel/utils/RedactUtils.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/utils/RedactUtils.java
@@ -24,7 +24,7 @@ import java.util.Properties;
 import java.util.regex.Pattern;
 
 /**
- * Reference from https://issues.apache.org/jira/browse/SPARK-18535
+ * Refer to https://issues.apache.org/jira/browse/SPARK-18535
  * Redact the sensitive values in the given properties. If a map key matches the redaction pattern then
  * its value is replaced with a dummy text.
  */

--- a/angel-ps/core/src/main/java/com/tencent/angel/utils/RedactUtils.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/utils/RedactUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Tencent is pleased to support the open source community by making Angel available.
+ *
+ * Copyright (C) 2017-2018 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package com.tencent.angel.utils;
+
+import com.tencent.angel.conf.AngelConf;
+import org.apache.hadoop.conf.Configuration;
+
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+/**
+ * Reference from https://issues.apache.org/jira/browse/SPARK-18535
+ * Redact the sensitive values in the given properties. If a map key matches the redaction pattern then
+ * its value is replaced with a dummy text.
+ */
+public final class RedactUtils {
+    private static final String REDACTION_REPLACEMENT_TEXT = "*********(redacted)";
+
+    /**
+     * Looks up the redaction regex from within the key value pairs and uses it to redact the rest
+     * of the key value pairs. No care is taken to make sure the redaction property itself is not
+     * redacted. So theoretically, the property itself could be configured to redact its own value
+     * when printing.
+     */
+    public static Properties redactProperties(Configuration conf, Properties originalProperties) {
+        Pattern redactionPattern = Pattern.compile(conf.get(AngelConf.ANGEL_REDACTION_REGEX, AngelConf.DEFAULT_ANGEL_REDACTION_REGEX));
+        Properties redactedProperties = new Properties();
+
+        originalProperties.forEach((key, value) -> {
+            if(redactionPattern.matcher((String)key).find() || redactionPattern.matcher((String)value).find()) {
+                redactedProperties.put(key, REDACTION_REPLACEMENT_TEXT);
+            }else {
+                redactedProperties.put(key, value);
+            }
+        });
+
+        return redactedProperties;
+    }
+}

--- a/angel-ps/core/src/main/java/com/tencent/angel/webapp/page/EnvironmentBlock.java
+++ b/angel-ps/core/src/main/java/com/tencent/angel/webapp/page/EnvironmentBlock.java
@@ -21,6 +21,7 @@ package com.tencent.angel.webapp.page;
 import com.google.inject.Inject;
 import com.tencent.angel.conf.AngelConf;
 import com.tencent.angel.master.app.AMContext;
+import com.tencent.angel.utils.RedactUtils;
 import org.apache.hadoop.yarn.webapp.hamlet.Hamlet;
 import org.apache.hadoop.yarn.webapp.hamlet.Hamlet.TABLE;
 import org.apache.hadoop.yarn.webapp.hamlet.Hamlet.TBODY;
@@ -65,15 +66,14 @@ public class EnvironmentBlock extends HtmlBlock {
     TABLE<Hamlet> angel_properties_table = html.table();
     angel_properties_table.tr().th(_TH, "NAME").th(_TH, "VALUE")._();
     AngelConf angelConfiguration = new AngelConf(this.amContext.getConf());
-    Properties propertiesConfiguration = angelConfiguration.getAngelProps();
-    SortedMap sortedMap = new TreeMap(propertiesConfiguration);
+    SortedMap sortedMap = new TreeMap(RedactUtils.redactProperties(this.amContext.getConf(), angelConfiguration.getAngelProps()));
     Set<Object> set = sortedMap.keySet();
     Iterator<Object> propertiesSortedKeys = set.iterator();
     Object key;
     while (propertiesSortedKeys.hasNext()) {
       key = propertiesSortedKeys.next();
       angel_properties_table.tr().td(String.valueOf(key))
-        .td((String) propertiesConfiguration.get(key))._();
+        .td((String) sortedMap.get(key))._();
     }
     angel_properties_table._();
     html.h1("    ");
@@ -82,7 +82,7 @@ public class EnvironmentBlock extends HtmlBlock {
     TBODY<TABLE<Hamlet>> tbody =
       html.h1("System Properties").table("#jobs").thead().tr().th(_TH, "NAME").th(_TH, "VALUE")._()
         ._().tbody();
-    Properties properties = System.getProperties();
+    Properties properties = RedactUtils.redactProperties(this.amContext.getConf(), System.getProperties());
     String propertiesName;
     String propertiesValue;
     for (Iterator<?> names = (Iterator<?>) properties.propertyNames(); names.hasNext(); ) {

--- a/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/context/AngelPSContext.scala
+++ b/spark-on-angel/core/src/main/scala/com/tencent/angel/spark/context/AngelPSContext.scala
@@ -363,6 +363,9 @@ object AngelPSContext {
     hadoopConf.set(ANGEL_QUEUE, queue)
     hadoopConf.set(ANGEL_DEPLOY_MODE, deployMode)
 
+    // setting REDACTION_REGEX
+    hadoopConf.set(ANGEL_REDACTION_REGEX, conf.get(ANGEL_REDACTION_REGEX, DEFAULT_ANGEL_REDACTION_REGEX))
+
     // For local mode, we set heartbeat a small value for fast debugging
     if (deployMode == "LOCAL")
       hadoopConf.set(ANGEL_PS_HEARTBEAT_INTERVAL_MS, "200")


### PR DESCRIPTION
Refer to  https://issues.apache.org/jira/browse/SPARK-18535

There are often some sensitive configurations in Hadoop configuration that need to be redacted, which have been processed by default in spark ui, 
but sensitive fields can still be displayed in Angel's environment page, it is very dangerous.
so we try to redact properties simlar to spark.

manual test works well like below:
![QQ截图20210223184102](https://user-images.githubusercontent.com/52202080/108832655-cb711800-7606-11eb-88fa-f8d0a9394252.png)

